### PR TITLE
Revamp messaging, campaigns, and workspace UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Twilio Credentials
 TWILIO_ACCOUNT_SID=your_account_sid
 TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_MESSAGING_SERVICE_SID=your_messaging_service_sid
 
 # Base URL for webhooks (replace with your actual URL in production)
 NEXT_PUBLIC_BASE_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Create an `.env.local` file with the following variables:
 # Twilio Credentials
 TWILIO_ACCOUNT_SID=your_account_sid
 TWILIO_AUTH_TOKEN=your_auth_token
+TWILIO_MESSAGING_SERVICE_SID=your_messaging_service_sid
 
 # Base URL for webhooks
 NEXT_PUBLIC_BASE_URL=your_base_url

--- a/package.json
+++ b/package.json
@@ -46,5 +46,10 @@
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
+  },
+  "overrides": {
+    "@next/swc": "15.5.11",
+    "@next/swc-linux-x64-gnu": "15.5.11",
+    "@next/swc-linux-x64-musl": "15.5.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.475.0",
-    "next": "^15.2.0",
+    "next": "15.5.11",
     "next-themes": "^0.4.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -42,7 +42,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "eslint": "^9",
-    "eslint-config-next": "15.1.7",
+    "eslint-config-next": "15.5.11",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"

--- a/src/app/api/twilio/bulk/route.ts
+++ b/src/app/api/twilio/bulk/route.ts
@@ -1,0 +1,61 @@
+import { NextResponse } from "next/server";
+import { sendTwilioMessage, type TwilioSendOptions } from "@/lib/twilio-server";
+
+type BulkRequest = {
+  recipients?: string[];
+  body?: string;
+  options?: TwilioSendOptions;
+};
+
+export async function POST(request: Request) {
+  try {
+    const payload = (await request.json()) as BulkRequest;
+    const recipients = payload.recipients?.filter(Boolean) ?? [];
+    const body = payload.body?.trim();
+
+    if (!recipients.length || !body) {
+      return NextResponse.json(
+        { success: false, error: "Missing recipients or message body." },
+        { status: 400 }
+      );
+    }
+
+    const results = await Promise.all(
+      recipients.map(async (to) => {
+        try {
+          const message = await sendTwilioMessage({
+            to,
+            body,
+            options: payload.options,
+          });
+          return {
+            success: true,
+            to,
+            messageSid: message.sid,
+            status: message.status,
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Failed to send message.";
+          return {
+            success: false,
+            to,
+            error: message,
+          };
+        }
+      })
+    );
+
+    const sent = results.filter((result) => result.success).length;
+
+    return NextResponse.json({
+      success: sent === recipients.length,
+      total: recipients.length,
+      sent,
+      failed: recipients.length - sent,
+      results,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to send bulk messages.";
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/twilio/send/route.ts
+++ b/src/app/api/twilio/send/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+import { sendTwilioMessage, type TwilioSendOptions } from "@/lib/twilio-server";
+
+type SendRequest = {
+  to?: string;
+  body?: string;
+  options?: TwilioSendOptions;
+};
+
+export async function POST(request: Request) {
+  try {
+    const payload = (await request.json()) as SendRequest;
+    const to = payload.to?.trim();
+    const body = payload.body?.trim();
+
+    if (!to || !body) {
+      return NextResponse.json(
+        { success: false, error: "Missing destination number or message body." },
+        { status: 400 }
+      );
+    }
+
+    const message = await sendTwilioMessage({ to, body, options: payload.options });
+
+    return NextResponse.json({
+      success: true,
+      messageSid: message.sid,
+      status: message.status,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to send message.";
+    return NextResponse.json({ success: false, error: message }, { status: 500 });
+  }
+}

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { useRouter } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
@@ -20,17 +21,19 @@ import {
   Upload,
 } from "lucide-react";
 
-export default function CampaignDetailsPage({
-  params,
-}: {
-  params: { id: string };
-}) {
+export default function CampaignDetailsPage() {
   const [campaign, setCampaign] = useState<CampaignRecord | null>(null);
   const [messageDraft, setMessageDraft] = useState("");
+  const [saveTemplate, setSaveTemplate] = useState(true);
+  const [logTestMessage, setLogTestMessage] = useState(true);
+  const params = useParams<{ id: string }>();
   const router = useRouter();
 
   useEffect(() => {
     const fetchCampaign = async () => {
+      if (!params?.id) {
+        return;
+      }
       const result = await campaignService.getCampaign(params.id);
       if (result.success) {
         setCampaign(result.campaign);
@@ -40,7 +43,7 @@ export default function CampaignDetailsPage({
       }
     };
     fetchCampaign();
-  }, [params.id, router]);
+  }, [params?.id, router]);
 
   const stats = useMemo(() => {
     if (!campaign) {
@@ -142,6 +145,10 @@ export default function CampaignDetailsPage({
 }`}
                   </pre>
                 </div>
+                <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+                  Hook campaigns use a static template. Each inbound webhook payload
+                  merges variables into the template before sending.
+                </div>
                 <div className="flex items-center gap-2 text-xs text-muted-foreground">
                   <ShieldCheck className="h-4 w-4 text-emerald-500" />
                   Safe Mode is enabled, outbound sends will be simulated.
@@ -181,6 +188,13 @@ export default function CampaignDetailsPage({
               <Button variant="outline" size="sm" className="w-full">
                 Edit Templates
               </Button>
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Checkbox
+                  checked={saveTemplate}
+                  onCheckedChange={(checked) => setSaveTemplate(Boolean(checked))}
+                />
+                Save edits to this template
+              </label>
             </div>
             <div className="space-y-2">
               <label className="text-xs font-medium uppercase text-muted-foreground">
@@ -204,6 +218,13 @@ export default function CampaignDetailsPage({
                 <Input placeholder="+1 (555) 555-5555" />
                 <Button size="sm">Send test</Button>
               </div>
+              <label className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Checkbox
+                  checked={logTestMessage}
+                  onCheckedChange={(checked) => setLogTestMessage(Boolean(checked))}
+                />
+                Log test message to audit + analytics
+              </label>
             </div>
             <Button className="w-full flex items-center gap-2">
               <Copy className="h-4 w-4" />

--- a/src/app/campaigns/[id]/page.tsx
+++ b/src/app/campaigns/[id]/page.tsx
@@ -1,164 +1,77 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { campaignService, CampaignRecord } from "@/lib/campaign";
 import {
   ArrowLeft,
   BarChart3,
-  MessageCircle,
-  Users,
-  AlertCircle,
-  PlayCircle,
-  PauseCircle,
-  Edit,
-  Trash,
   Copy,
-  Calendar,
-  CheckCircle,
-  RefreshCw,
+  PauseCircle,
+  PlayCircle,
+  ShieldCheck,
+  Upload,
 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
-import { campaignService } from "@/lib/campaign";
-
-interface Campaign {
-  id: string;
-  name: string;
-  description: string;
-  status: "draft" | "scheduled" | "active" | "paused" | "completed";
-  createdAt: string;
-  scheduledFor?: string;
-  completedAt?: string;
-  totalContacts: number;
-  sentCount: number;
-  responseCount: number;
-  tags: string[];
-  message: string;
-}
 
 export default function CampaignDetailsPage({
   params,
 }: {
   params: { id: string };
 }) {
-  const [campaign, setCampaign] = useState<Campaign | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [runningCampaign, setRunningCampaign] = useState(false);
+  const [campaign, setCampaign] = useState<CampaignRecord | null>(null);
+  const [messageDraft, setMessageDraft] = useState("");
   const router = useRouter();
-  const { toast } = useToast();
 
-  // Fetch campaign details
   useEffect(() => {
     const fetchCampaign = async () => {
-      setLoading(true);
-      try {
-        const result = await campaignService.getCampaign(params.id);
-        if (result.success) {
-          setCampaign(result.campaign as Campaign);
-        } else {
-          toast({
-            title: "Error",
-            description: "Campaign not found",
-            variant: "destructive",
-          });
-          router.push("/campaigns");
-        }
-      } catch (error) {
-        toast({
-          title: "Error",
-          description: "Failed to load campaign details",
-          variant: "destructive",
-        });
-      } finally {
-        setLoading(false);
+      const result = await campaignService.getCampaign(params.id);
+      if (result.success) {
+        setCampaign(result.campaign);
+        setMessageDraft(result.campaign.message);
+      } else {
+        router.push("/campaigns");
       }
     };
-
     fetchCampaign();
-  }, [params.id, router, toast]);
+  }, [params.id, router]);
 
-  // Handle campaign actions
-  const handleRunCampaign = async () => {
-    if (!campaign) return;
-    
-    setRunningCampaign(true);
-    try {
-      const result = await campaignService.runCampaign(campaign.id);
-      if (result.success) {
-        toast({
-          title: "Campaign started",
-          description: "Campaign is now running",
-        });
-        // In a real app, would refresh the campaign status
-        setCampaign({
-          ...campaign,
-          status: "active",
-        });
-      } else {
-        throw new Error(result.error || "Failed to run campaign");
-      }
-    } catch (error: any) {
-      toast({
-        title: "Error",
-        description: error.message || "Failed to run campaign",
-        variant: "destructive",
-      });
-    } finally {
-      setRunningCampaign(false);
+  const stats = useMemo(() => {
+    if (!campaign) {
+      return [];
     }
-  };
-
-  // Get badge color based on campaign status
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "active":
-        return "bg-green-500";
-      case "scheduled":
-        return "bg-blue-500";
-      case "draft":
-        return "bg-gray-500";
-      case "paused":
-        return "bg-orange-500";
-      case "completed":
-        return "bg-purple-500";
-      default:
-        return "";
-    }
-  };
-
-  if (loading) {
-    return (
-      <DashboardLayout>
-        <div className="flex justify-center items-center h-96">
-          <p>Loading campaign details...</p>
-        </div>
-      </DashboardLayout>
-    );
-  }
+    const { stats } = campaign;
+    const deliveredPct = stats.sent ? Math.round((stats.delivered / stats.sent) * 100) : 0;
+    const respondedPct = stats.sent ? Math.round((stats.responded / stats.sent) * 100) : 0;
+    const stoppedPct = stats.sent ? Math.round((stats.stop / stats.sent) * 100) : 0;
+    return [
+      { label: "Total contacts", value: campaign.stats.sent + campaign.stats.stop },
+      { label: "Sent", value: stats.sent },
+      { label: "Undelivered", value: stats.sent - stats.delivered },
+      { label: "Delivered", value: stats.delivered },
+      { label: "Responded", value: stats.responded },
+      { label: "Invalid numbers", value: Math.max(0, stats.sent - stats.delivered - stats.stop) },
+      { label: "Spam", value: stats.spam },
+      { label: "Stop", value: stats.stop },
+      { label: "Clicks", value: stats.clicks },
+      { label: "Segments", value: stats.segments },
+      { label: "% responded", value: `${respondedPct}%` },
+      { label: "% delivered", value: `${deliveredPct}%` },
+      { label: "% stopped", value: `${stoppedPct}%` },
+    ];
+  }, [campaign]);
 
   if (!campaign) {
     return (
       <DashboardLayout>
-        <div className="flex flex-col items-center justify-center h-96">
-          <AlertCircle className="h-12 w-12 text-muted-foreground mb-4" />
-          <h2 className="text-2xl font-bold">Campaign Not Found</h2>
-          <p className="text-muted-foreground mb-4">
-            The campaign you are looking for does not exist.
-          </p>
-          <Button onClick={() => router.push("/campaigns")}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Campaigns
-          </Button>
+        <div className="flex h-96 items-center justify-center text-muted-foreground">
+          Loading campaign details...
         </div>
       </DashboardLayout>
     );
@@ -167,281 +80,137 @@ export default function CampaignDetailsPage({
   return (
     <DashboardLayout>
       <div className="flex flex-col gap-6">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={() => router.push("/campaigns")}
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <h1 className="text-3xl font-bold">{campaign.name}</h1>
-          <Badge className={`ml-2 ${getStatusBadge(campaign.status)}`} variant="secondary">
-            {campaign.status.charAt(0).toUpperCase() + campaign.status.slice(1)}
-          </Badge>
-        </div>
-
-        <p className="text-muted-foreground">{campaign.description}</p>
-
-        <div className="flex flex-wrap gap-4 mb-4">
-          <div className="flex items-center">
-            <Calendar className="mr-2 h-4 w-4 text-muted-foreground" />
-            <span className="text-sm">
-              Created: {new Date(campaign.createdAt).toLocaleDateString()}
-            </span>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex items-center gap-3">
+            <Button variant="outline" size="icon" onClick={() => router.push("/campaigns")}>
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <div>
+              <h1 className="text-2xl font-bold">{campaign.name}</h1>
+              <p className="text-xs text-muted-foreground">
+                ID {campaign.id} · Created {new Date(campaign.createdAt).toLocaleString()}
+              </p>
+            </div>
+            <Badge variant="secondary">{campaign.type}</Badge>
           </div>
-          {campaign.scheduledFor && (
-            <div className="flex items-center">
-              <Calendar className="mr-2 h-4 w-4 text-muted-foreground" />
-              <span className="text-sm">
-                Scheduled: {new Date(campaign.scheduledFor).toLocaleDateString()}
-              </span>
-            </div>
-          )}
-          {campaign.completedAt && (
-            <div className="flex items-center">
-              <CheckCircle className="mr-2 h-4 w-4 text-muted-foreground" />
-              <span className="text-sm">
-                Completed: {new Date(campaign.completedAt).toLocaleDateString()}
-              </span>
-            </div>
-          )}
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" className="flex items-center gap-2">
+              <PauseCircle className="h-4 w-4" />
+              Pause
+            </Button>
+            <Button variant="outline" className="flex items-center gap-2">
+              <PlayCircle className="h-4 w-4" />
+              Cancel
+            </Button>
+            <Button className="flex items-center gap-2">
+              <BarChart3 className="h-4 w-4" />
+              Analytics
+            </Button>
+          </div>
         </div>
 
-        <div className="flex flex-wrap gap-4 md:flex-nowrap">
-          <Card className="flex-1">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium">
-                Total Contacts
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{campaign.totalContacts}</div>
-              <div className="flex items-center mt-1">
-                <Users className="h-4 w-4 text-muted-foreground mr-1" />
-                <p className="text-xs text-muted-foreground">
-                  Target audience size
-                </p>
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_320px]">
+          <div className="space-y-6">
+            <Card className="p-4">
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {stats.map((stat) => (
+                  <div key={stat.label} className="rounded-lg border p-3">
+                    <p className="text-xs uppercase text-muted-foreground">{stat.label}</p>
+                    <p className="text-lg font-semibold">{stat.value}</p>
+                  </div>
+                ))}
               </div>
-            </CardContent>
-          </Card>
-
-          <Card className="flex-1">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium">
-                Messages Sent
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">{campaign.sentCount}</div>
-              <div className="flex items-center mt-1">
-                <MessageCircle className="h-4 w-4 text-muted-foreground mr-1" />
-                <p className="text-xs text-muted-foreground">
-                  {campaign.totalContacts > 0
-                    ? `${Math.round(
-                        (campaign.sentCount / campaign.totalContacts) * 100
-                      )}% of total`
-                    : "No contacts selected"}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card className="flex-1">
-            <CardHeader className="pb-2">
-              <CardTitle className="text-sm font-medium">
-                Response Rate
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="text-2xl font-bold">
-                {campaign.sentCount > 0
-                  ? `${Math.round(
-                      (campaign.responseCount / campaign.sentCount) * 100
-                    )}%`
-                  : "N/A"}
-              </div>
-              <div className="flex items-center mt-1">
-                <BarChart3 className="h-4 w-4 text-muted-foreground mr-1" />
-                <p className="text-xs text-muted-foreground">
-                  {campaign.responseCount} responses received
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-
-        <Tabs defaultValue="details" className="w-full">
-          <TabsList>
-            <TabsTrigger value="details">Details</TabsTrigger>
-            <TabsTrigger value="performance">Performance</TabsTrigger>
-            <TabsTrigger value="responses">Responses</TabsTrigger>
-          </TabsList>
-
-          <TabsContent value="details" className="space-y-4">
-            <Card>
-              <CardHeader>
-                <CardTitle>Campaign Message</CardTitle>
-                <CardDescription>
-                  The message that will be sent to your contacts
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="p-4 bg-muted rounded-md">
-                  <p className="whitespace-pre-wrap">{campaign.message}</p>
-                </div>
-
-                <div className="flex gap-2 mt-6">
-                  {campaign.status === "draft" && (
-                    <Button
-                      className="flex items-center"
-                      onClick={handleRunCampaign}
-                      disabled={runningCampaign}
-                    >
-                      {runningCampaign ? (
-                        <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
-                      ) : (
-                        <PlayCircle className="mr-2 h-4 w-4" />
-                      )}
-                      Run Campaign
-                    </Button>
-                  )}
-                  {campaign.status === "active" && (
-                    <Button
-                      variant="outline"
-                      className="flex items-center"
-                      disabled={runningCampaign}
-                    >
-                      <PauseCircle className="mr-2 h-4 w-4" />
-                      Pause Campaign
-                    </Button>
-                  )}
-                  {campaign.status === "paused" && (
-                    <Button
-                      className="flex items-center"
-                      disabled={runningCampaign}
-                    >
-                      <PlayCircle className="mr-2 h-4 w-4" />
-                      Resume Campaign
-                    </Button>
-                  )}
-                  <Button variant="outline" className="flex items-center">
-                    <Edit className="mr-2 h-4 w-4" />
-                    Edit
-                  </Button>
-                  <Button variant="outline" className="flex items-center">
-                    <Copy className="mr-2 h-4 w-4" />
-                    Duplicate
-                  </Button>
-                  <Button
-                    variant="outline"
-                    className="flex items-center text-destructive"
-                  >
-                    <Trash className="mr-2 h-4 w-4" />
-                    Delete
-                  </Button>
-                </div>
-              </CardContent>
             </Card>
 
-            <Card>
-              <CardHeader>
-                <CardTitle>Campaign Tags</CardTitle>
-                <CardDescription>
-                  Tags associated with this campaign
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="flex flex-wrap gap-2">
-                  {campaign.tags.map((tag) => (
-                    <Badge key={tag} variant="outline">
-                      {tag}
-                    </Badge>
-                  ))}
-                  {campaign.tags.length === 0 && (
-                    <p className="text-sm text-muted-foreground">
-                      No tags associated with this campaign
-                    </p>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-
-          <TabsContent value="performance">
-            <Card>
-              <CardHeader>
-                <CardTitle>Campaign Performance</CardTitle>
-                <CardDescription>
-                  Analytics and metrics for this campaign
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="h-[300px] flex items-center justify-center border rounded-md bg-muted/50">
-                  <p className="text-muted-foreground">
-                    Performance visualization would be displayed here
+            {campaign.type === "Hook" && (
+              <Card className="p-5 space-y-4">
+                <div>
+                  <h2 className="text-lg font-semibold">Setting up your Hook Campaign</h2>
+                  <p className="text-sm text-muted-foreground">
+                    Trigger texts programmatically via the workspace API key.
                   </p>
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
+                <div className="rounded-lg border bg-muted/40 p-4 text-sm">
+                  <p className="font-medium">POST {campaign.hookEndpoint}</p>
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    Header: <span className="font-medium">X-API-Key: &lt;key&gt;</span>
+                  </p>
+                  <pre className="mt-3 whitespace-pre-wrap text-xs text-muted-foreground">
+{`{
+  "number": "+15555555555",
+  "vars": { "name": "John", "amount": "50000" }
+}`}
+                  </pre>
+                </div>
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <ShieldCheck className="h-4 w-4 text-emerald-500" />
+                  Safe Mode is enabled, outbound sends will be simulated.
+                </div>
+              </Card>
+            )}
+          </div>
 
-          <TabsContent value="responses">
-            <Card>
-              <CardHeader>
-                <CardTitle>Campaign Responses</CardTitle>
-                <CardDescription>
-                  Messages received in response to this campaign
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {campaign.responseCount > 0 ? (
-                  <div className="space-y-4">
-                    <div className="flex items-start p-4 border rounded-md">
-                      <div className="bg-primary text-primary-foreground rounded-full w-8 h-8 flex items-center justify-center mr-3">
-                        <Users className="h-4 w-4" />
-                      </div>
-                      <div>
-                        <div className="flex items-center">
-                          <p className="font-medium">+12025550101</p>
-                          <span className="text-xs text-muted-foreground ml-2">
-                            2 hours ago
-                          </span>
-                        </div>
-                        <p className="mt-1">Yes, I'm interested in learning more!</p>
-                      </div>
-                    </div>
-                    
-                    <div className="flex items-start p-4 border rounded-md">
-                      <div className="bg-primary text-primary-foreground rounded-full w-8 h-8 flex items-center justify-center mr-3">
-                        <Users className="h-4 w-4" />
-                      </div>
-                      <div>
-                        <div className="flex items-center">
-                          <p className="font-medium">+12025550102</p>
-                          <span className="text-xs text-muted-foreground ml-2">
-                            4 hours ago
-                          </span>
-                        </div>
-                        <p className="mt-1">Please unsubscribe me from future messages.</p>
-                      </div>
-                    </div>
-                  </div>
-                ) : (
-                  <div className="flex flex-col items-center justify-center p-8 text-center">
-                    <MessageCircle className="mb-2 h-10 w-10 text-muted-foreground" />
-                    <h3 className="text-lg font-medium">No responses yet</h3>
-                    <p className="text-sm text-muted-foreground">
-                      {campaign.status === "completed"
-                        ? "This campaign didn't receive any responses."
-                        : "Responses will appear here as they are received."}
-                    </p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+          <Card className="flex flex-col gap-4 p-4">
+            <div className="space-y-1">
+              <h2 className="text-sm font-semibold">Message Builder</h2>
+              <p className="text-xs text-muted-foreground">
+                Edit templates, insert variables, and attach media.
+              </p>
+            </div>
+            <div className="rounded-lg border border-dashed p-4 text-center text-sm text-muted-foreground">
+              <Upload className="mx-auto mb-2 h-5 w-5" />
+              Include image upload (optional MMS)
+              <Button variant="outline" size="sm" className="mt-3 w-full">
+                Upload media
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Select Template
+              </label>
+              <Select defaultValue="default">
+                <SelectTrigger>
+                  <SelectValue placeholder="Select template" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="default">Default Template</SelectItem>
+                  <SelectItem value="demo">Demo Scheduler</SelectItem>
+                  <SelectItem value="renewal">Renewal Reminder</SelectItem>
+                </SelectContent>
+              </Select>
+              <Button variant="outline" size="sm" className="w-full">
+                Edit Templates
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Edit your text message
+              </label>
+              <Textarea
+                rows={6}
+                value={messageDraft}
+                onChange={(event) => setMessageDraft(event.target.value)}
+              />
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>Variables supported: {"{name}"}, {"{amount}"}, {"{link}"}</span>
+                <span>{messageDraft.length} chars</span>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Test Send
+              </label>
+              <div className="flex items-center gap-2">
+                <Input placeholder="+1 (555) 555-5555" />
+                <Button size="sm">Send test</Button>
+              </div>
+            </div>
+            <Button className="w-full flex items-center gap-2">
+              <Copy className="h-4 w-4" />
+              Copy campaign payload
+            </Button>
+          </Card>
+        </div>
       </div>
     </DashboardLayout>
   );

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -1,18 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import {
   Table,
   TableBody,
@@ -21,362 +14,177 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { campaignService, CampaignRecord } from "@/lib/campaign";
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  BarChart,
+  Download,
+  Eye,
+  FileText,
+  Pencil,
   Plus,
   Search,
-  MessageCircle,
-  Calendar,
-  MoreHorizontal,
-  PlayCircle,
-  PauseCircle,
-  User,
-  Edit,
   Trash,
 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
-import { campaignService } from "@/lib/campaign";
-
-interface Campaign {
-  id: string;
-  name: string;
-  description: string;
-  status: "draft" | "scheduled" | "active" | "paused" | "completed";
-  createdAt: string;
-  scheduledFor?: string;
-  completedAt?: string;
-  totalContacts: number;
-  sentCount: number;
-  responseCount: number;
-  tags: string[];
-  message: string;
-}
+import { Badge } from "@/components/ui/badge";
 
 export default function CampaignsPage() {
-  const [campaigns, setCampaigns] = useState<Campaign[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [campaigns, setCampaigns] = useState<CampaignRecord[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
-  const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [newCampaign, setNewCampaign] = useState({
-    name: "",
-    description: "",
-    message: "",
-  });
+  const [showArchived, setShowArchived] = useState(false);
   const router = useRouter();
-  const { toast } = useToast();
 
-  // Fetch campaigns (simulated)
-  useState(() => {
+  useEffect(() => {
     const fetchCampaigns = async () => {
-      setLoading(true);
-      try {
-        const result = await campaignService.getCampaigns();
-        if (result.success) {
-          setCampaigns(result.campaigns as Campaign[]);
-        }
-      } catch (error) {
-        toast({
-          title: "Error",
-          description: "Failed to load campaigns",
-          variant: "destructive",
-        });
-      } finally {
-        setLoading(false);
+      const result = await campaignService.getCampaigns();
+      if (result.success) {
+        setCampaigns(result.campaigns);
       }
     };
-
     fetchCampaigns();
-  });
+  }, []);
 
-  // Filtered campaigns based on search
-  const filteredCampaigns = campaigns.filter(
-    (campaign) =>
-      campaign.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      campaign.description.toLowerCase().includes(searchQuery.toLowerCase())
-  );
-
-  // Handle campaign creation
-  const handleCreateCampaign = async () => {
-    if (!newCampaign.name || !newCampaign.message) return;
-
-    try {
-      const result = await campaignService.createCampaign(newCampaign);
-      if (result.success) {
-        toast({
-          title: "Campaign created",
-          description: "Campaign has been created successfully",
-        });
-        setCampaigns([...campaigns, result.campaign as Campaign]);
-        setCreateDialogOpen(false);
-        setNewCampaign({ name: "", description: "", message: "" });
+  const filteredCampaigns = useMemo(() => {
+    return campaigns.filter((campaign) => {
+      if (!showArchived && campaign.status === "completed") {
+        return false;
       }
-    } catch (error) {
-      toast({
-        title: "Error",
-        description: "Failed to create campaign",
-        variant: "destructive",
-      });
-    }
-  };
+      const query = searchQuery.toLowerCase();
+      return (
+        campaign.name.toLowerCase().includes(query) ||
+        campaign.type.toLowerCase().includes(query) ||
+        campaign.createdBy.toLowerCase().includes(query)
+      );
+    });
+  }, [campaigns, searchQuery, showArchived]);
 
-  // Handle view campaign details
   const handleViewCampaign = (id: string) => {
     router.push(`/campaigns/${id}`);
-  };
-
-  // Get badge color based on campaign status
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case "active":
-        return "bg-green-500";
-      case "scheduled":
-        return "bg-blue-500";
-      case "draft":
-        return "bg-gray-500";
-      case "paused":
-        return "bg-orange-500";
-      case "completed":
-        return "bg-purple-500";
-      default:
-        return "";
-    }
   };
 
   return (
     <DashboardLayout>
       <div className="flex flex-col gap-6">
-        <div className="flex justify-between items-center">
-          <h1 className="text-3xl font-bold">Campaigns</h1>
-          <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-            <DialogTrigger asChild>
-              <Button className="flex items-center">
-                <Plus className="mr-2 h-4 w-4" />
-                Create Campaign
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="sm:max-w-[600px]">
-              <DialogHeader>
-                <DialogTitle>Create New Campaign</DialogTitle>
-                <DialogDescription>
-                  Create a new SMS campaign to engage with your audience.
-                </DialogDescription>
-              </DialogHeader>
-              <div className="grid gap-4 py-4">
-                <div>
-                  <Label htmlFor="campaign-name">Campaign Name</Label>
-                  <Input
-                    id="campaign-name"
-                    placeholder="Enter campaign name"
-                    value={newCampaign.name}
-                    onChange={(e) =>
-                      setNewCampaign({ ...newCampaign, name: e.target.value })
-                    }
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="campaign-description">Description</Label>
-                  <Input
-                    id="campaign-description"
-                    placeholder="Enter campaign description"
-                    value={newCampaign.description}
-                    onChange={(e) =>
-                      setNewCampaign({
-                        ...newCampaign,
-                        description: e.target.value,
-                      })
-                    }
-                  />
-                </div>
-                <div>
-                  <Label htmlFor="campaign-message">Message</Label>
-                  <Textarea
-                    id="campaign-message"
-                    placeholder="Enter the message to send"
-                    rows={4}
-                    value={newCampaign.message}
-                    onChange={(e) =>
-                      setNewCampaign({ ...newCampaign, message: e.target.value })
-                    }
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Use {{name}} as a placeholder for recipient's name.
-                  </p>
-                </div>
-              </div>
-              <DialogFooter>
-                <Button
-                  variant="outline"
-                  onClick={() => setCreateDialogOpen(false)}
-                >
-                  Cancel
-                </Button>
-                <Button onClick={handleCreateCampaign}>Create</Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-        </div>
-
-        <div className="flex items-center mb-4">
-          <div className="relative w-full max-w-md">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search campaigns..."
-              className="pl-8"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-            />
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold">Campaigns</h1>
+            <p className="text-sm text-muted-foreground">
+              Launch, monitor, and optimize your SMS campaigns.
+            </p>
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <Button variant="outline" className="flex items-center gap-2">
+              <Download className="h-4 w-4" />
+              Download CSV
+            </Button>
+            <Button className="flex items-center gap-2">
+              <Plus className="h-4 w-4" />
+              Create Campaign
+            </Button>
           </div>
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>All Campaigns</CardTitle>
-            <CardDescription>
-              Manage and track your SMS marketing campaigns
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
-            {loading ? (
-              <div className="flex justify-center p-4">
-                <p>Loading campaigns...</p>
+        <Card className="p-4">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                className="pl-9"
+                placeholder="Search campaigns..."
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+              />
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant={showArchived ? "default" : "outline"}
+                onClick={() => setShowArchived((prev) => !prev)}
+              >
+                Show Archived
+              </Button>
+              <div className="flex items-center gap-2 rounded-full border px-3 py-1 text-xs text-muted-foreground">
+                <span>Subscriber</span>
+                <span className="h-3 w-px bg-border" />
+                <span>Retarget</span>
+                <span className="h-3 w-px bg-border" />
+                <span>Manual</span>
               </div>
-            ) : filteredCampaigns.length === 0 ? (
-              <div className="flex flex-col items-center justify-center p-8 text-center">
-                <MessageCircle className="mb-2 h-10 w-10 text-muted-foreground" />
-                <h3 className="text-lg font-medium">No campaigns found</h3>
-                <p className="text-sm text-muted-foreground">
-                  {searchQuery
-                    ? "No campaigns match your search query"
-                    : "Create your first campaign to get started"}
-                </p>
-                {!searchQuery && (
-                  <Button
-                    className="mt-4"
-                    onClick={() => setCreateDialogOpen(true)}
-                  >
-                    <Plus className="mr-2 h-4 w-4" />
-                    Create Campaign
-                  </Button>
-                )}
-              </div>
-            ) : (
-              <div className="overflow-x-auto">
-                <Table>
-                  <TableHeader>
-                    <TableRow>
-                      <TableHead>Campaign</TableHead>
-                      <TableHead>Status</TableHead>
-                      <TableHead>Contacts</TableHead>
-                      <TableHead>Response Rate</TableHead>
-                      <TableHead>Created</TableHead>
-                      <TableHead className="text-right">Actions</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {filteredCampaigns.map((campaign) => (
-                      <TableRow
-                        key={campaign.id}
-                        className="cursor-pointer"
+            </div>
+          </div>
+        </Card>
+
+        <Card className="overflow-hidden">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Campaign</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Created by</TableHead>
+                <TableHead>Created at</TableHead>
+                <TableHead>Sent</TableHead>
+                <TableHead>Delivered</TableHead>
+                <TableHead>Responded</TableHead>
+                <TableHead>Stop</TableHead>
+                <TableHead>Spam</TableHead>
+                <TableHead>Clicks</TableHead>
+                <TableHead>Segments</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredCampaigns.map((campaign) => (
+                <TableRow
+                  key={campaign.id}
+                  className="cursor-pointer hover:bg-muted/40"
+                  onClick={() => handleViewCampaign(campaign.id)}
+                >
+                  <TableCell>
+                    <div className="flex flex-col">
+                      <span className="font-medium">{campaign.name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {campaign.id}
+                      </span>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant="secondary">{campaign.type}</Badge>
+                  </TableCell>
+                  <TableCell>{campaign.createdBy}</TableCell>
+                  <TableCell>
+                    {new Date(campaign.createdAt).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell>{campaign.stats.sent}</TableCell>
+                  <TableCell>{campaign.stats.delivered}</TableCell>
+                  <TableCell>{campaign.stats.responded}</TableCell>
+                  <TableCell>{campaign.stats.stop}</TableCell>
+                  <TableCell>{campaign.stats.spam}</TableCell>
+                  <TableCell>{campaign.stats.clicks}</TableCell>
+                  <TableCell>{campaign.stats.segments}</TableCell>
+                  <TableCell className="text-right">
+                    <div
+                      className="flex justify-end gap-2"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      <Button
+                        size="icon"
+                        variant="ghost"
                         onClick={() => handleViewCampaign(campaign.id)}
                       >
-                        <TableCell>
-                          <div>
-                            <div className="font-medium">{campaign.name}</div>
-                            <div className="text-sm text-muted-foreground">
-                              {campaign.description}
-                            </div>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            className={`${getStatusBadge(campaign.status)}`}
-                            variant="secondary"
-                          >
-                            {campaign.status.charAt(0).toUpperCase() +
-                              campaign.status.slice(1)}
-                          </Badge>
-                        </TableCell>
-                        <TableCell>
-                          <div className="flex items-center">
-                            <User className="mr-2 h-4 w-4 text-muted-foreground" />
-                            <span>
-                              {campaign.sentCount}/{campaign.totalContacts}
-                            </span>
-                          </div>
-                        </TableCell>
-                        <TableCell>
-                          {campaign.sentCount > 0
-                            ? `${Math.round(
-                                (campaign.responseCount / campaign.sentCount) *
-                                  100
-                              )}%`
-                            : "N/A"}
-                        </TableCell>
-                        <TableCell>
-                          {new Date(campaign.createdAt).toLocaleDateString()}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          <div
-                            className="flex justify-end space-x-2"
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <Button
-                              variant="outline"
-                              size="icon"
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleViewCampaign(campaign.id);
-                              }}
-                            >
-                              <BarChart className="h-4 w-4" />
-                            </Button>
-                            {campaign.status === "active" && (
-                              <Button
-                                variant="outline"
-                                size="icon"
-                                className="text-orange-500"
-                              >
-                                <PauseCircle className="h-4 w-4" />
-                              </Button>
-                            )}
-                            {campaign.status === "paused" && (
-                              <Button
-                                variant="outline"
-                                size="icon"
-                                className="text-green-500"
-                              >
-                                <PlayCircle className="h-4 w-4" />
-                              </Button>
-                            )}
-                            {campaign.status === "draft" && (
-                              <Button
-                                variant="outline"
-                                size="icon"
-                                className="text-green-500"
-                              >
-                                <PlayCircle className="h-4 w-4" />
-                              </Button>
-                            )}
-                          </div>
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </CardContent>
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                      <Button size="icon" variant="ghost">
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button size="icon" variant="ghost">
+                        <FileText className="h-4 w-4" />
+                      </Button>
+                      <Button size="icon" variant="ghost">
+                        <Trash className="h-4 w-4 text-destructive" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
         </Card>
       </div>
     </DashboardLayout>

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -49,7 +49,7 @@ export default function CampaignsPage() {
       }
       const query = searchQuery.toLowerCase();
       return (
-        campaign.name.toLowerCase().includes(query) ||
+        (campaign.name ?? "").toLowerCase().includes(query) ||
         campaign.type.toLowerCase().includes(query) ||
         campaign.createdBy.toLowerCase().includes(query)
       );

--- a/src/app/campaigns/page.tsx
+++ b/src/app/campaigns/page.tsx
@@ -138,7 +138,9 @@ export default function CampaignsPage() {
                 >
                   <TableCell>
                     <div className="flex flex-col">
-                      <span className="font-medium">{campaign.name}</span>
+                      <span className="font-medium">
+                        {campaign.name ?? "Untitled campaign"}
+                      </span>
                       <span className="text-xs text-muted-foreground">
                         {campaign.id}
                       </span>

--- a/src/app/claims/page.tsx
+++ b/src/app/claims/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Phone, Search } from "lucide-react";
+
+export default function ClaimsPage() {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-3xl font-bold">Claims</h1>
+          <p className="text-sm text-muted-foreground">
+            Search, purchase, and assign phone numbers to your workspace.
+          </p>
+        </div>
+
+        <Card className="p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input className="pl-9" placeholder="Search by area code or city" />
+            </div>
+            <Button>Search Numbers</Button>
+          </div>
+        </Card>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {["+1 (312) 555-0133", "+1 (415) 555-0182", "+1 (917) 555-0174"].map(
+            (number) => (
+              <Card key={number} className="flex items-center justify-between p-4">
+                <div className="flex items-center gap-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                    <Phone className="h-4 w-4" />
+                  </div>
+                  <div>
+                    <p className="font-medium">{number}</p>
+                    <p className="text-xs text-muted-foreground">Local SMS</p>
+                  </div>
+                </div>
+                <Button variant="outline" size="sm">
+                  Claim
+                </Button>
+              </Card>
+            )
+          )}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/contacts/page.tsx
+++ b/src/app/contacts/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Search, User } from "lucide-react";
+
+const contacts = [
+  { name: "Jordan Matthews", phone: "+1 (202) 555-0121", status: "Active", tags: ["VIP"] },
+  { name: "Nina Alvarez", phone: "+1 (415) 555-0184", status: "Stopped", tags: ["Stop"] },
+  { name: "Devon Park", phone: "+1 (312) 555-0140", status: "Active", tags: ["Demo"] },
+];
+
+export default function ContactsPage() {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold">Contacts</h1>
+            <p className="text-sm text-muted-foreground">
+              Manage contacts, flags, and stop list status.
+            </p>
+          </div>
+          <Button>Add Contact</Button>
+        </div>
+
+        <Card className="p-4">
+          <div className="relative w-full max-w-md">
+            <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+            <Input className="pl-9" placeholder="Search contacts..." />
+          </div>
+        </Card>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {contacts.map((contact) => (
+            <Card key={contact.phone} className="p-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                  <User className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="font-medium">{contact.name}</p>
+                  <p className="text-xs text-muted-foreground">{contact.phone}</p>
+                </div>
+              </div>
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                <Badge variant="secondary">{contact.status}</Badge>
+                {contact.tags.map((tag) => (
+                  <Badge key={tag} variant="outline">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,6 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import ClientBody from "./ClientBody";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Onryl | SMS Marketing Platform",
@@ -24,8 +13,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${geistSans.variable} ${geistMono.variable}`}>
-      <body suppressHydrationWarning className="antialiased">
+    <html lang="en">
+      <body suppressHydrationWarning className="antialiased font-sans">
         <ClientBody>{children}</ClientBody>
       </body>
     </html>

--- a/src/app/lookups/page.tsx
+++ b/src/app/lookups/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { BadgeCheck, Phone, Search } from "lucide-react";
+
+export default function LookupsPage() {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-3xl font-bold">Lookups</h1>
+          <p className="text-sm text-muted-foreground">
+            Validate numbers and check carrier or line type.
+          </p>
+        </div>
+
+        <Card className="p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input className="pl-9" placeholder="Enter phone number" />
+            </div>
+            <Button>Lookup</Button>
+          </div>
+        </Card>
+
+        <Card className="p-4">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+              <Phone className="h-4 w-4" />
+            </div>
+            <div>
+              <p className="font-medium">+1 (415) 555-0184</p>
+              <p className="text-xs text-muted-foreground">Carrier: Verizon · Line type: Mobile</p>
+            </div>
+            <div className="ml-auto flex items-center gap-2 text-xs text-emerald-600">
+              <BadgeCheck className="h-4 w-4" />
+              Valid
+            </div>
+          </div>
+        </Card>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -1,359 +1,508 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
-import { 
-  Card, 
-  CardContent, 
-  CardHeader, 
-  CardTitle, 
-  CardDescription 
-} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { 
-  MessageSquare, 
-  Send, 
-  Phone, 
-  User, 
-  Users, 
-  Clock,
-  RefreshCw,
-  CheckCircle2
+import {
+  ArrowUpDown,
+  BadgeCheck,
+  Bookmark,
+  CircleDot,
+  Download,
+  MessageSquare,
+  PhoneCall,
+  Search,
+  Send,
+  ShieldCheck,
+  Tag,
+  User,
 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
-import { sendSMS, sendBulkSMS } from "@/lib/twilio";
 
-interface Message {
+type RepliedStatus = "both" | "replied" | "not_replied";
+
+interface Channel {
   id: string;
-  from: string;
-  to: string;
+  contactName: string;
+  contactNumber: string;
+  lastMessage: string;
+  lastMessageAt: string;
+  unreadCount: number;
+  flags: string[];
+  bookmarked: boolean;
+  replied: boolean;
+  campaign: string;
+}
+
+interface ChatMessage {
+  id: string;
+  channelId: string;
+  direction: "inbound" | "outbound";
   body: string;
-  direction: 'inbound' | 'outbound';
-  status: 'delivered' | 'sent' | 'failed' | 'received';
+  status: "queued" | "sent" | "delivered" | "failed" | "simulated";
   timestamp: string;
 }
 
-// Mock messages data for display
-const mockMessages: Message[] = [
+const channels: Channel[] = [
   {
-    id: '1',
-    from: '+12025550101',
-    to: '+12025550142',
-    body: 'Hi, I\'m interested in learning more about your service',
-    direction: 'inbound',
-    status: 'received',
-    timestamp: '2025-05-23T09:15:00Z',
+    id: "ch_01",
+    contactName: "Jordan Matthews",
+    contactNumber: "+1 (202) 555-0121",
+    lastMessage: "Got it — can we move this to next week?",
+    lastMessageAt: "2m ago",
+    unreadCount: 2,
+    flags: ["VIP", "Renewal"],
+    bookmarked: true,
+    replied: true,
+    campaign: "Renewal Reminder",
   },
   {
-    id: '2',
-    from: '+12025550142',
-    to: '+12025550101',
-    body: 'Thanks for reaching out! We offer SMS marketing automation and campaign management. What specific features are you looking for?',
-    direction: 'outbound',
-    status: 'delivered',
-    timestamp: '2025-05-23T09:20:00Z',
+    id: "ch_02",
+    contactName: "Nina Alvarez",
+    contactNumber: "+1 (415) 555-0184",
+    lastMessage: "STOP",
+    lastMessageAt: "12m ago",
+    unreadCount: 1,
+    flags: ["Stop"],
+    bookmarked: false,
+    replied: true,
+    campaign: "Retarget Q2",
   },
   {
-    id: '3',
-    from: '+12025550102',
-    to: '+12025550142',
-    body: 'When will the new features be available?',
-    direction: 'inbound',
-    status: 'received',
-    timestamp: '2025-05-23T10:05:00Z',
+    id: "ch_03",
+    contactName: "Open Lead",
+    contactNumber: "+1 (646) 555-0166",
+    lastMessage: "Thanks! Can you send pricing?",
+    lastMessageAt: "1h ago",
+    unreadCount: 0,
+    flags: ["Pricing"],
+    bookmarked: false,
+    replied: false,
+    campaign: "Welcome Blast",
   },
   {
-    id: '4',
-    from: '+12025550142',
-    to: '+12025550102',
-    body: 'Our new features will be released next week! You\'ll be able to use advanced segmentation and A/B testing.',
-    direction: 'outbound',
-    status: 'delivered',
-    timestamp: '2025-05-23T10:10:00Z',
+    id: "ch_04",
+    contactName: "Devon Park",
+    contactNumber: "+1 (312) 555-0140",
+    lastMessage: "We’re ready to schedule the demo.",
+    lastMessageAt: "3h ago",
+    unreadCount: 0,
+    flags: ["Demo"],
+    bookmarked: true,
+    replied: true,
+    campaign: "Hook: Demo",
+  },
+];
+
+const chatMessages: ChatMessage[] = [
+  {
+    id: "m1",
+    channelId: "ch_01",
+    direction: "inbound",
+    body: "Hey team, appreciate the follow up.",
+    status: "delivered",
+    timestamp: "Today 9:12 AM",
   },
   {
-    id: '5',
-    from: '+12025550103',
-    to: '+12025550142',
-    body: 'I need help with my account',
-    direction: 'inbound',
-    status: 'received',
-    timestamp: '2025-05-23T11:30:00Z',
+    id: "m2",
+    channelId: "ch_01",
+    direction: "outbound",
+    body: "Absolutely! Want to push your renewal to next week?",
+    status: "delivered",
+    timestamp: "Today 9:14 AM",
+  },
+  {
+    id: "m3",
+    channelId: "ch_01",
+    direction: "inbound",
+    body: "Got it — can we move this to next week?",
+    status: "delivered",
+    timestamp: "Today 9:16 AM",
+  },
+  {
+    id: "m4",
+    channelId: "ch_02",
+    direction: "inbound",
+    body: "STOP",
+    status: "delivered",
+    timestamp: "Today 8:55 AM",
+  },
+  {
+    id: "m5",
+    channelId: "ch_03",
+    direction: "outbound",
+    body: "Welcome! Let me know what you’re looking for.",
+    status: "delivered",
+    timestamp: "Yesterday 4:18 PM",
+  },
+  {
+    id: "m6",
+    channelId: "ch_03",
+    direction: "inbound",
+    body: "Thanks! Can you send pricing?",
+    status: "delivered",
+    timestamp: "Yesterday 4:24 PM",
   },
 ];
 
 export default function MessagesPage() {
-  const [activeConversation, setActiveConversation] = useState<string | null>('+12025550101');
-  const [messageText, setMessageText] = useState('');
-  const [bulkRecipients, setBulkRecipients] = useState('');
-  const [bulkMessage, setBulkMessage] = useState('');
-  const [isSending, setIsSending] = useState(false);
-  const [isSendingBulk, setIsSendingBulk] = useState(false);
-  const { toast } = useToast();
+  const [selectedChannelId, setSelectedChannelId] = useState(channels[0].id);
+  const [search, setSearch] = useState("");
+  const [campaignFilter, setCampaignFilter] = useState<string>("all");
+  const [flagFilter, setFlagFilter] = useState<string>("all");
+  const [unreadOnly, setUnreadOnly] = useState(false);
+  const [bookmarkedOnly, setBookmarkedOnly] = useState(false);
+  const [repliedStatus, setRepliedStatus] = useState<RepliedStatus>("both");
+  const [orderOldest, setOrderOldest] = useState(false);
+  const [safeMode, setSafeMode] = useState(true);
+  const [composer, setComposer] = useState("");
 
-  // Filter messages for the active conversation
-  const conversationMessages = mockMessages.filter(
-    msg => msg.from === activeConversation || msg.to === activeConversation
-  ).sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+  const segmentCount = Math.max(1, Math.ceil(composer.length / 160));
 
-  // Get unique contacts from messages
-  const contacts = Array.from(
-    new Set(
-      mockMessages.map(msg => 
-        msg.direction === 'inbound' ? msg.from : msg.to
-      ).filter(number => number !== '+12025550142')
-    )
+  const filteredChannels = useMemo(() => {
+    return channels
+      .filter((channel) => {
+        const matchesSearch =
+          channel.contactName.toLowerCase().includes(search.toLowerCase()) ||
+          channel.contactNumber.toLowerCase().includes(search.toLowerCase()) ||
+          channel.lastMessage.toLowerCase().includes(search.toLowerCase());
+        const matchesCampaign =
+          campaignFilter === "all" || channel.campaign === campaignFilter;
+        const matchesFlag =
+          flagFilter === "all" || channel.flags.includes(flagFilter);
+        const matchesUnread = !unreadOnly || channel.unreadCount > 0;
+        const matchesBookmarked = !bookmarkedOnly || channel.bookmarked;
+        const matchesReplied =
+          repliedStatus === "both" ||
+          (repliedStatus === "replied" && channel.replied) ||
+          (repliedStatus === "not_replied" && !channel.replied);
+        return (
+          matchesSearch &&
+          matchesCampaign &&
+          matchesFlag &&
+          matchesUnread &&
+          matchesBookmarked &&
+          matchesReplied
+        );
+      })
+      .sort((a, b) =>
+        orderOldest
+          ? a.lastMessageAt.localeCompare(b.lastMessageAt)
+          : b.lastMessageAt.localeCompare(a.lastMessageAt)
+      );
+  }, [
+    campaignFilter,
+    flagFilter,
+    bookmarkedOnly,
+    orderOldest,
+    repliedStatus,
+    search,
+    unreadOnly,
+  ]);
+
+  const activeChannel = channels.find(
+    (channel) => channel.id === selectedChannelId
   );
 
-  // Handle sending a single message
-  const handleSendMessage = async () => {
-    if (!messageText.trim() || !activeConversation) return;
-    
-    setIsSending(true);
-    
-    try {
-      // In a real app, this would send through Twilio
-      const result = await sendSMS(activeConversation, messageText);
-      
-      if (result.success) {
-        toast({
-          title: "Message sent",
-          description: "Your message has been sent successfully",
-        });
-        setMessageText('');
-      } else {
-        throw new Error(result.error || 'Failed to send message');
-      }
-    } catch (error: any) {
-      toast({
-        title: "Error",
-        description: error.message || "Failed to send message",
-        variant: "destructive",
-      });
-    } finally {
-      setIsSending(false);
-    }
-  };
-
-  // Handle sending bulk messages
-  const handleSendBulkMessages = async () => {
-    if (!bulkMessage.trim() || !bulkRecipients.trim()) return;
-    
-    const recipients = bulkRecipients.split(',').map(r => r.trim());
-    if (recipients.length === 0) return;
-    
-    setIsSendingBulk(true);
-    
-    try {
-      // In a real app, this would send through Twilio
-      const result = await sendBulkSMS(recipients, bulkMessage);
-      
-      if (result.success) {
-        toast({
-          title: "Bulk messages sent",
-          description: `Successfully sent to ${result.sent}/${recipients.length} recipients`,
-        });
-        setBulkMessage('');
-        setBulkRecipients('');
-      } else {
-        throw new Error(result.error || 'Failed to send bulk messages');
-      }
-    } catch (error: any) {
-      toast({
-        title: "Error",
-        description: error.message || "Failed to send bulk messages",
-        variant: "destructive",
-      });
-    } finally {
-      setIsSendingBulk(false);
-    }
-  };
+  const activeMessages = chatMessages.filter(
+    (message) => message.channelId === selectedChannelId
+  );
 
   return (
     <DashboardLayout>
       <div className="flex flex-col gap-6">
-        <h1 className="text-3xl font-bold">Messages</h1>
-        
-        <Tabs defaultValue="conversations" className="w-full">
-          <TabsList>
-            <TabsTrigger value="conversations" className="flex items-center">
-              <MessageSquare className="mr-2 h-4 w-4" />
-              Conversations
-            </TabsTrigger>
-            <TabsTrigger value="bulk" className="flex items-center">
-              <Users className="mr-2 h-4 w-4" />
-              Bulk Messaging
-            </TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="conversations">
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-              {/* Contacts/Conversations List */}
-              <Card className="md:col-span-1">
-                <CardHeader>
-                  <CardTitle>Conversations</CardTitle>
-                  <div className="mt-2">
-                    <Input placeholder="Search contacts..." />
-                  </div>
-                </CardHeader>
-                <CardContent>
-                  <div className="space-y-2">
-                    {contacts.map(contact => (
-                      <div 
-                        key={contact}
-                        className={`flex items-center p-3 rounded-md cursor-pointer hover:bg-muted ${
-                          activeConversation === contact ? 'bg-muted' : ''
-                        }`}
-                        onClick={() => setActiveConversation(contact)}
-                      >
-                        <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground">
-                          <User className="h-4 w-4" />
-                        </div>
-                        <div className="ml-3">
-                          <p className="text-sm font-medium">{contact}</p>
-                          <p className="text-xs text-muted-foreground">
-                            Last message: {new Date().toLocaleDateString()}
-                          </p>
-                        </div>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold">Messages</h1>
+            <p className="text-sm text-muted-foreground">
+              Real-time inbox across every workspace channel.
+            </p>
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 rounded-full border px-3 py-1">
+              <ShieldCheck className="h-4 w-4 text-emerald-500" />
+              <span className="text-sm font-medium">Safe Mode</span>
+              <Checkbox
+                checked={safeMode}
+                onCheckedChange={(checked) => setSafeMode(Boolean(checked))}
+              />
+            </div>
+            <Button variant="outline" className="flex items-center gap-2">
+              <Download className="h-4 w-4" />
+              Export CSV
+            </Button>
+          </div>
+        </div>
+
+        <div className="grid gap-6 xl:grid-cols-[320px_minmax(0,1fr)_320px]">
+          <Card className="flex flex-col gap-4 p-4">
+            <div className="space-y-2">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{filteredChannels.length} channels</span>
+                <span>
+                  {filteredChannels.reduce((acc, channel) => acc + channel.unreadCount, 0)}{" "}
+                  unread
+                </span>
+              </div>
+              <div className="relative">
+                <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                <Input
+                  className="pl-9"
+                  placeholder="Search by name, number, or text"
+                  value={search}
+                  onChange={(event) => setSearch(event.target.value)}
+                />
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="grid gap-2">
+                <Select value={campaignFilter} onValueChange={setCampaignFilter}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Campaigns" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All campaigns</SelectItem>
+                    <SelectItem value="Renewal Reminder">Renewal Reminder</SelectItem>
+                    <SelectItem value="Retarget Q2">Retarget Q2</SelectItem>
+                    <SelectItem value="Welcome Blast">Welcome Blast</SelectItem>
+                    <SelectItem value="Hook: Demo">Hook: Demo</SelectItem>
+                  </SelectContent>
+                </Select>
+                <Select value={flagFilter} onValueChange={setFlagFilter}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Flags" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All flags</SelectItem>
+                    <SelectItem value="VIP">VIP</SelectItem>
+                    <SelectItem value="Renewal">Renewal</SelectItem>
+                    <SelectItem value="Stop">Stop</SelectItem>
+                    <SelectItem value="Pricing">Pricing</SelectItem>
+                    <SelectItem value="Demo">Demo</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="grid gap-2">
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={unreadOnly}
+                    onCheckedChange={(checked) => setUnreadOnly(Boolean(checked))}
+                  />
+                  Unread only
+                </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={bookmarkedOnly}
+                    onCheckedChange={(checked) => setBookmarkedOnly(Boolean(checked))}
+                  />
+                  Bookmarked
+                </label>
+              </div>
+
+              <Select
+                value={repliedStatus}
+                onValueChange={(value: RepliedStatus) => setRepliedStatus(value)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Replied status" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="both">Both</SelectItem>
+                  <SelectItem value="replied">Replied</SelectItem>
+                  <SelectItem value="not_replied">Not replied</SelectItem>
+                </SelectContent>
+              </Select>
+
+              <Button
+                variant="outline"
+                className="w-full justify-between"
+                onClick={() => setOrderOldest((prev) => !prev)}
+              >
+                Order by oldest
+                <ArrowUpDown className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              {filteredChannels.map((channel) => (
+                <button
+                  key={channel.id}
+                  onClick={() => setSelectedChannelId(channel.id)}
+                  className={`flex w-full flex-col gap-2 rounded-lg border px-3 py-2 text-left transition ${
+                    selectedChannelId === channel.id
+                      ? "border-primary bg-primary/5"
+                      : "border-transparent hover:border-muted"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted">
+                        <User className="h-4 w-4" />
                       </div>
-                    ))}
-                  </div>
-                </CardContent>
-              </Card>
-              
-              {/* Message Thread */}
-              <Card className="md:col-span-2">
-                <CardHeader>
-                  <CardTitle className="flex items-center">
-                    <div className="w-8 h-8 rounded-full bg-primary flex items-center justify-center text-primary-foreground">
-                      <User className="h-4 w-4" />
+                      <div>
+                        <p className="text-sm font-medium">{channel.contactName}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {channel.contactNumber}
+                        </p>
+                      </div>
                     </div>
-                    <span className="ml-3">{activeConversation || 'Select a conversation'}</span>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="flex flex-col space-y-4 h-[400px] overflow-y-auto mb-4">
-                    {activeConversation ? (
-                      conversationMessages.map(message => (
-                        <div 
-                          key={message.id}
-                          className={`flex ${
-                            message.direction === 'outbound' ? 'justify-end' : 'justify-start'
-                          }`}
-                        >
-                          <div className={`max-w-[70%] p-3 rounded-lg ${
-                            message.direction === 'outbound' 
-                              ? 'bg-primary text-primary-foreground rounded-tr-none' 
-                              : 'bg-muted rounded-tl-none'
-                          }`}>
-                            <p className="text-sm">{message.body}</p>
-                            <div className="flex items-center mt-1">
-                              <Clock className="h-3 w-3 mr-1 opacity-70" />
-                              <p className="text-xs opacity-70">
-                                {new Date(message.timestamp).toLocaleTimeString([], {
-                                  hour: '2-digit',
-                                  minute: '2-digit'
-                                })}
-                              </p>
-                              {message.direction === 'outbound' && (
-                                <div className="flex items-center ml-2">
-                                  <CheckCircle2 className="h-3 w-3 opacity-70" />
-                                </div>
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      ))
-                    ) : (
-                      <div className="flex items-center justify-center h-full">
-                        <p className="text-muted-foreground">Select a conversation to view messages</p>
-                      </div>
+                    {channel.unreadCount > 0 && (
+                      <Badge className="h-5 rounded-full px-2 text-xs">
+                        {channel.unreadCount}
+                      </Badge>
                     )}
                   </div>
-                  
-                  {activeConversation && (
-                    <div className="flex space-x-2">
-                      <Textarea 
-                        placeholder="Type your message..." 
-                        className="flex-1"
-                        value={messageText}
-                        onChange={(e) => setMessageText(e.target.value)}
-                        disabled={isSending}
-                      />
-                      <Button 
-                        onClick={handleSendMessage}
-                        disabled={!messageText.trim() || isSending}
-                      >
-                        {isSending ? (
-                          <RefreshCw className="h-4 w-4 animate-spin" />
-                        ) : (
-                          <Send className="h-4 w-4" />
-                        )}
-                      </Button>
+                  <p className="text-xs text-muted-foreground line-clamp-2">
+                    {channel.lastMessage}
+                  </p>
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{channel.lastMessageAt}</span>
+                    <div className="flex items-center gap-2">
+                      {channel.bookmarked && <Bookmark className="h-3 w-3" />}
+                      {channel.flags.length > 0 && <Tag className="h-3 w-3" />}
                     </div>
-                  )}
-                </CardContent>
-              </Card>
+                  </div>
+                </button>
+              ))}
             </div>
-          </TabsContent>
-          
-          <TabsContent value="bulk">
-            <Card>
-              <CardHeader>
-                <CardTitle>Bulk Messaging</CardTitle>
-                <CardDescription>
-                  Send messages to multiple recipients at once
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-4">
+          </Card>
+
+          <Card className="flex flex-col">
+            <div className="border-b px-5 py-4">
+              <div className="flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                  <PhoneCall className="h-4 w-4" />
+                </div>
                 <div>
-                  <label className="text-sm font-medium mb-1 block">Recipients</label>
-                  <Textarea 
-                    placeholder="Enter phone numbers separated by commas..."
-                    value={bulkRecipients}
-                    onChange={(e) => setBulkRecipients(e.target.value)}
-                    disabled={isSendingBulk}
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    Format: +12025550101, +12025550102, etc.
+                  <p className="text-sm font-semibold">
+                    {activeChannel ? activeChannel.contactName : "No channel selected"}
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    {activeChannel?.contactNumber ?? "Select a channel on the left"}
                   </p>
                 </div>
-                
-                <div>
-                  <label className="text-sm font-medium mb-1 block">Message</label>
-                  <Textarea 
-                    placeholder="Type your message..."
-                    className="h-32"
-                    value={bulkMessage}
-                    onChange={(e) => setBulkMessage(e.target.value)}
-                    disabled={isSendingBulk}
-                  />
+              </div>
+            </div>
+
+            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+              {activeChannel ? (
+                activeMessages.map((message) => (
+                  <div
+                    key={message.id}
+                    className={`flex ${
+                      message.direction === "outbound" ? "justify-end" : "justify-start"
+                    }`}
+                  >
+                    <div
+                      className={`max-w-[70%] rounded-2xl px-4 py-3 text-sm ${
+                        message.direction === "outbound"
+                          ? "bg-primary text-primary-foreground"
+                          : "bg-muted"
+                      }`}
+                    >
+                      <p>{message.body}</p>
+                      <div className="mt-2 flex items-center justify-between text-xs opacity-70">
+                        <span>{message.timestamp}</span>
+                        <span className="flex items-center gap-1">
+                          <CircleDot className="h-3 w-3" />
+                          {message.status}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))
+              ) : (
+                <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+                  Select a channel on the left to begin chatting.
                 </div>
-                
-                <Button 
-                  className="w-full" 
-                  onClick={handleSendBulkMessages}
-                  disabled={!bulkMessage.trim() || !bulkRecipients.trim() || isSendingBulk}
-                >
-                  {isSendingBulk ? (
-                    <>
-                      <RefreshCw className="mr-2 h-4 w-4 animate-spin" />
-                      Sending...
-                    </>
-                  ) : (
-                    <>
-                      <Send className="mr-2 h-4 w-4" />
-                      Send Bulk Messages
-                    </>
-                  )}
-                </Button>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+              )}
+            </div>
+
+            <div className="border-t px-5 py-4">
+              <div className="flex flex-col gap-3">
+                <Textarea
+                  placeholder="Type your message..."
+                  value={composer}
+                  onChange={(event) => setComposer(event.target.value)}
+                  rows={3}
+                />
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <MessageSquare className="h-4 w-4" />
+                    {composer.length} chars · {segmentCount} segment
+                    {segmentCount > 1 ? "s" : ""}
+                    {safeMode && (
+                      <span className="flex items-center gap-1 text-emerald-600">
+                        <BadgeCheck className="h-3 w-3" />
+                        Safe Mode
+                      </span>
+                    )}
+                  </div>
+                  <Button className="flex items-center gap-2">
+                    <Send className="h-4 w-4" />
+                    Send Message
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          <Card className="flex flex-col gap-4 p-4">
+            <div>
+              <p className="text-sm font-semibold">Channel Metadata</p>
+              <p className="text-xs text-muted-foreground">
+                {activeChannel ? "Contact details and status" : "Select a channel."}
+              </p>
+            </div>
+
+            {activeChannel ? (
+              <div className="space-y-4 text-sm">
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">Contact</p>
+                  <p className="font-medium">{activeChannel.contactName}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {activeChannel.contactNumber}
+                  </p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">Tags</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {activeChannel.flags.map((flag) => (
+                      <Badge key={flag} variant="secondary">
+                        {flag}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">Last campaign</p>
+                  <p className="font-medium">{activeChannel.campaign}</p>
+                </div>
+                <div className="rounded-lg border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">Status</p>
+                  <p className="font-medium">
+                    {activeChannel.replied ? "Replied" : "Not replied"}
+                  </p>
+                </div>
+                <div className="space-y-2 rounded-lg border p-3">
+                  <p className="text-xs uppercase text-muted-foreground">Notes</p>
+                  <Textarea placeholder="Add internal notes..." rows={4} />
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-lg border p-4 text-sm text-muted-foreground">
+                Select a channel to see contact metadata, tags, and notes.
+              </div>
+            )}
+          </Card>
+        </div>
       </div>
     </DashboardLayout>
   );

--- a/src/app/messages/page.tsx
+++ b/src/app/messages/page.tsx
@@ -427,6 +427,25 @@ export default function MessagesPage() {
 
             <div className="border-t px-5 py-4">
               <div className="flex flex-col gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs font-medium text-muted-foreground">
+                    Auto-response suggestions
+                  </span>
+                  {[
+                    "Happy to help — what’s the best time to connect?",
+                    "Got it. Want me to send pricing details?",
+                    "Thanks! Reply STOP to opt out at any time.",
+                  ].map((suggestion) => (
+                    <button
+                      key={suggestion}
+                      type="button"
+                      className="rounded-full border px-3 py-1 text-xs text-muted-foreground transition hover:bg-muted"
+                      onClick={() => setComposer(suggestion)}
+                    >
+                      {suggestion}
+                    </button>
+                  ))}
+                </div>
                 <Textarea
                   placeholder="Type your message..."
                   value={composer}

--- a/src/app/subscribers/page.tsx
+++ b/src/app/subscribers/page.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { ListFilter, Plus, Search } from "lucide-react";
+
+const segments = [
+  { name: "All Subscribers", count: 12840, type: "Default" },
+  { name: "Retarget - No Reply 7d", count: 1840, type: "Retarget" },
+  { name: "VIP Renewals", count: 320, type: "Manual" },
+];
+
+export default function SubscribersPage() {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold">Subscribers</h1>
+            <p className="text-sm text-muted-foreground">
+              Build lists, segments, and manual filters for campaigns.
+            </p>
+          </div>
+          <Button className="flex items-center gap-2">
+            <Plus className="h-4 w-4" />
+            New Segment
+          </Button>
+        </div>
+
+        <Card className="p-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="relative w-full max-w-md">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input className="pl-9" placeholder="Search segments..." />
+            </div>
+            <Button variant="outline" className="flex items-center gap-2">
+              <ListFilter className="h-4 w-4" />
+              Filters
+            </Button>
+          </div>
+        </Card>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {segments.map((segment) => (
+            <Card key={segment.name} className="p-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="font-medium">{segment.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {segment.count.toLocaleString()} subscribers
+                  </p>
+                </div>
+                <Badge variant="secondary">{segment.type}</Badge>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { DashboardLayout } from "@/components/layout/DashboardLayout";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Activity,
+  BadgeCheck,
+  CreditCard,
+  Database,
+  FileClock,
+  Flag,
+  Link,
+  Lock,
+  PhoneOff,
+  Settings,
+  Shield,
+  Users,
+  Webhook,
+} from "lucide-react";
+
+const settingsCards = [
+  { title: "Users", description: "Invite users and manage roles.", icon: Users },
+  { title: "Workspace Flags", description: "Create flag labels for channels.", icon: Flag },
+  { title: "Blocked Numbers", description: "Manage suppression list.", icon: PhoneOff },
+  { title: "Billing", description: "Usage, invoices, and limits.", icon: CreditCard },
+  { title: "Settings", description: "Timezone, safe mode defaults, sticky sender.", icon: Settings },
+  { title: "Message Management", description: "Compliance warnings and blacklists.", icon: Shield },
+  { title: "API", description: "Generate and rotate API keys.", icon: Lock },
+  { title: "Webhooks", description: "Outbound event subscriptions.", icon: Webhook },
+  { title: "10DLC", description: "Brand + campaign registration status.", icon: BadgeCheck },
+  { title: "Integrations", description: "CRM connectors and data sync.", icon: Link },
+  { title: "Logs", description: "Audit log viewer.", icon: FileClock },
+  { title: "CRM Management", description: "Webhook auth + field mapping.", icon: Database },
+];
+
+export default function WorkspacePage() {
+  return (
+    <DashboardLayout>
+      <div className="flex flex-col gap-6">
+        <div>
+          <h1 className="text-3xl font-bold">Workspace Settings</h1>
+          <p className="text-sm text-muted-foreground">
+            Configure your workspace, compliance controls, and integrations.
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+          {settingsCards.map((card) => {
+            const Icon = card.icon;
+            return (
+              <Card key={card.title} className="flex flex-col justify-between gap-6 p-5">
+                <div className="space-y-3">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-full bg-muted">
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <div>
+                    <h2 className="text-lg font-semibold">{card.title}</h2>
+                    <p className="text-sm text-muted-foreground">{card.description}</p>
+                  </div>
+                </div>
+                <Button variant="outline" className="self-start">
+                  Manage
+                </Button>
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -36,6 +36,21 @@ const settingsCards = [
   { title: "CRM Management", description: "Webhook auth + field mapping.", icon: Database },
 ];
 
+const messagingServices = [
+  {
+    name: "Default Messaging Service for Conversations",
+    sid: "MG68266bf9a248ad8d30d4b36adb752706",
+    inboundRequest: "https://onryl.app/webhooks/twilio/inbound",
+    linkShorteningDomain: "short.onryl.app",
+  },
+  {
+    name: "Customer Care A2P Messaging Service",
+    sid: "MGf0f492f616a93cfd65347426a88f334a",
+    inboundRequest: "https://onryl.app/webhooks/twilio/inbound",
+    linkShorteningDomain: "short.onryl.app",
+  },
+];
+
 export default function WorkspacePage() {
   return (
     <DashboardLayout>
@@ -92,6 +107,55 @@ export default function WorkspacePage() {
             <p className="text-xs text-muted-foreground">
               We’ll validate credentials and confirm webhook reachability.
             </p>
+          </div>
+        </Card>
+
+        <Card className="p-5">
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold">Messaging Services</h2>
+              <p className="text-sm text-muted-foreground">
+                Bundle sender numbers and inbound routing into a Twilio Messaging Service.
+              </p>
+            </div>
+            <Button>Create Messaging Service</Button>
+          </div>
+          <div className="mt-5 flex flex-wrap items-center gap-3">
+            <div className="flex flex-1 flex-wrap items-center gap-3">
+              <div className="min-w-[240px] flex-1">
+                <Input placeholder="Search by SID" />
+              </div>
+              <Button variant="outline">Search</Button>
+            </div>
+            <div className="rounded-full border px-3 py-1 text-xs text-muted-foreground">
+              10 per page
+            </div>
+          </div>
+          <div className="mt-5 overflow-hidden rounded-xl border">
+            <div className="grid grid-cols-4 gap-4 border-b bg-muted/30 px-4 py-3 text-xs font-semibold uppercase text-muted-foreground">
+              <span>Name</span>
+              <span>SID</span>
+              <span>Inbound Request Config</span>
+              <span>Link Shortening Domain</span>
+            </div>
+            {messagingServices.map((service) => (
+              <div
+                key={service.sid}
+                className="grid grid-cols-4 gap-4 border-b px-4 py-4 text-sm last:border-b-0"
+              >
+                <div className="space-y-1">
+                  <p className="font-medium text-primary">{service.name}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Manage senders and opt-out handling.
+                  </p>
+                </div>
+                <span className="font-mono text-xs text-muted-foreground">{service.sid}</span>
+                <span className="text-sm text-muted-foreground">{service.inboundRequest}</span>
+                <span className="text-sm text-muted-foreground">
+                  {service.linkShorteningDomain}
+                </span>
+              </div>
+            ))}
           </div>
         </Card>
 

--- a/src/app/workspace/page.tsx
+++ b/src/app/workspace/page.tsx
@@ -2,7 +2,9 @@
 
 import { DashboardLayout } from "@/components/layout/DashboardLayout";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 import {
   Activity,
   BadgeCheck,
@@ -44,6 +46,73 @@ export default function WorkspacePage() {
             Configure your workspace, compliance controls, and integrations.
           </p>
         </div>
+
+        <Card className="p-5">
+          <div className="flex flex-wrap items-start justify-between gap-6">
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold">Twilio Connection</h2>
+              <p className="text-sm text-muted-foreground">
+                Connect your Twilio account once and re-use it across every channel.
+              </p>
+            </div>
+            <div className="flex items-center gap-2 rounded-full border px-3 py-1 text-sm">
+              <span className="h-2 w-2 rounded-full bg-emerald-500" />
+              Connected
+            </div>
+          </div>
+          <div className="mt-6 grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Account SID
+              </label>
+              <Input placeholder="ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Auth Token
+              </label>
+              <Input placeholder="••••••••••••••••••••••••••••••" type="password" />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Messaging Service SID (optional)
+              </label>
+              <Input placeholder="MGXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" />
+            </div>
+            <div className="space-y-2">
+              <label className="text-xs font-medium uppercase text-muted-foreground">
+                Webhook Base URL
+              </label>
+              <Input placeholder="https://app.example.com/webhooks/twilio" />
+            </div>
+          </div>
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <Button>Save & Verify</Button>
+            <Button variant="outline">Send Test SMS</Button>
+            <p className="text-xs text-muted-foreground">
+              We’ll validate credentials and confirm webhook reachability.
+            </p>
+          </div>
+        </Card>
+
+        <Card className="p-5">
+          <div className="space-y-2">
+            <h2 className="text-lg font-semibold">Sticky Sender</h2>
+            <p className="text-sm text-muted-foreground">
+              Keep each contact paired with the same sender number for consistent
+              conversations and higher deliverability.
+            </p>
+          </div>
+          <div className="mt-4 flex items-center justify-between rounded-lg border p-4">
+            <div>
+              <p className="text-sm font-medium">Enable sticky sender per contact</p>
+              <p className="text-xs text-muted-foreground">
+                New contacts are assigned a sender number on first send.
+              </p>
+            </div>
+            <Checkbox defaultChecked />
+          </div>
+        </Card>
 
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           {settingsCards.map((card) => {

--- a/src/components/layout/DashboardLayout.tsx
+++ b/src/components/layout/DashboardLayout.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@/lib/utils";
 import { SideNav } from "./SideNav";
+import { TopBar } from "./TopBar";
 import { Toaster } from "@/components/ui/toaster";
 import { Toaster as Sonner } from "@/components/ui/sonner";
 
@@ -9,15 +10,18 @@ export function DashboardLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex min-h-screen">
       <SideNav />
-      <main
-        className={cn(
-          "flex-1 overflow-y-auto bg-background text-foreground px-6 pt-6 pb-12 md:px-8 md:pt-8"
-        )}
-      >
-        <div className="mx-auto max-w-7xl">{children}</div>
-        <Toaster />
-        <Sonner />
-      </main>
+      <div className="flex flex-1 flex-col overflow-hidden bg-background text-foreground">
+        <TopBar />
+        <main
+          className={cn(
+            "flex-1 overflow-y-auto px-6 pb-12 pt-6 md:px-8 md:pt-8"
+          )}
+        >
+          <div className="mx-auto max-w-7xl">{children}</div>
+          <Toaster />
+          <Sonner />
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/components/layout/SideNav.tsx
+++ b/src/components/layout/SideNav.tsx
@@ -9,8 +9,9 @@ import {
   ListTodo,
   Users,
   MessageCircle,
+  Sparkles,
+  Search,
   Settings,
-  Layout,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import Image from "next/image";
@@ -21,6 +22,8 @@ const links = [
   { name: "Campaigns", href: "/campaigns", icon: MessageCircle },
   { name: "Claims", href: "/claims", icon: ListTodo },
   { name: "Contacts", href: "/contacts", icon: Users },
+  { name: "Subscribers", href: "/subscribers", icon: Sparkles },
+  { name: "Lookups", href: "/lookups", icon: Search },
   { name: "Workspace", href: "/workspace", icon: Settings },
 ];
 

--- a/src/components/layout/TopBar.tsx
+++ b/src/components/layout/TopBar.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { Bell, ChevronDown, Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useState } from "react";
+
+const workspaces = [
+  { id: "ws_9k2z", name: "Northwind Health" },
+  { id: "ws_41v8", name: "Harbor Dental" },
+  { id: "ws_7b1q", name: "Kite Logistics" },
+];
+
+export function TopBar() {
+  const [isDark, setIsDark] = useState(false);
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-4 border-b bg-card px-6 py-4 md:px-8">
+      <div className="flex flex-wrap items-center gap-4">
+        <div>
+          <p className="text-xs font-medium uppercase text-muted-foreground">
+            Workspace
+          </p>
+          <div className="flex items-center gap-2">
+            <Select defaultValue={workspaces[0].id}>
+              <SelectTrigger className="h-9 w-[240px]">
+                <SelectValue placeholder="Select workspace" />
+              </SelectTrigger>
+              <SelectContent>
+                {workspaces.map((workspace) => (
+                  <SelectItem key={workspace.id} value={workspace.id}>
+                    {workspace.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <span className="rounded-full border px-2 py-1 text-xs text-muted-foreground">
+              {workspaces[0].id}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Toggle dark mode"
+          onClick={() => setIsDark((prev) => !prev)}
+        >
+          {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+        </Button>
+        <Button variant="ghost" size="icon" aria-label="Notifications">
+          <Bell className="h-4 w-4" />
+        </Button>
+        <Button variant="outline" className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-full bg-muted" />
+          <div className="text-left text-sm">
+            <p className="font-medium">Avery Hill</p>
+            <p className="text-xs text-muted-foreground">Admin</p>
+          </div>
+          <ChevronDown className="h-4 w-4 text-muted-foreground" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/campaign.ts
+++ b/src/lib/campaign.ts
@@ -1,286 +1,182 @@
-// Mock data for campaigns
-const campaigns = [
+export type CampaignType = "Hook" | "Single blast" | "Retarget";
+export type CampaignStatus = "draft" | "scheduled" | "active" | "paused" | "completed";
+
+export interface CampaignStats {
+  sent: number;
+  delivered: number;
+  responded: number;
+  stop: number;
+  spam: number;
+  clicks: number;
+  segments: number;
+}
+
+export interface CampaignRecord {
+  id: string;
+  name: string;
+  type: CampaignType;
+  status: CampaignStatus;
+  createdBy: string;
+  createdAt: string;
+  description: string;
+  templateId?: string;
+  hookEndpoint?: string;
+  message: string;
+  stats: CampaignStats;
+}
+
+const campaigns: CampaignRecord[] = [
   {
-    id: '1',
-    name: 'Welcome Campaign',
-    description: 'Initial outreach to new leads',
-    status: 'active',
-    createdAt: '2025-05-01T12:00:00Z',
-    totalContacts: 156,
-    sentCount: 145,
-    responseCount: 23,
-    tags: ['welcome', 'new-leads'],
-    message: 'Hi {{name}}, welcome to Onryl! Reply INFO to learn more about our services.',
+    id: "c_001",
+    name: "Renewal Reminder",
+    type: "Single blast",
+    status: "active",
+    createdBy: "Avery Hill",
+    createdAt: "2025-05-01T12:00:00Z",
+    description: "Renewal outreach for May accounts.",
+    message:
+      "Hi {name}, your plan renews soon. Reply YES to confirm or STOP to opt out.",
+    stats: {
+      sent: 1245,
+      delivered: 1188,
+      responded: 312,
+      stop: 18,
+      spam: 3,
+      clicks: 212,
+      segments: 1440,
+    },
   },
   {
-    id: '2',
-    name: 'Follow-up Campaign',
-    description: 'Follow up with leads who did not respond',
-    status: 'scheduled',
-    scheduledFor: '2025-05-25T10:00:00Z',
-    createdAt: '2025-05-10T15:30:00Z',
-    totalContacts: 87,
-    sentCount: 0,
-    responseCount: 0,
-    tags: ['follow-up', 'reminder'],
-    message: 'Hi {{name}}, just checking in - are you still interested in our services? Reply YES to learn more.',
+    id: "c_002",
+    name: "Retarget Q2",
+    type: "Retarget",
+    status: "paused",
+    createdBy: "Nina Patel",
+    createdAt: "2025-05-12T09:30:00Z",
+    description: "Retargeted follow-up for unresponsive leads.",
+    message:
+      "Still interested in getting your quote? We can schedule a 15-min call this week.",
+    stats: {
+      sent: 640,
+      delivered: 601,
+      responded: 94,
+      stop: 9,
+      spam: 2,
+      clicks: 54,
+      segments: 720,
+    },
   },
   {
-    id: '3',
-    name: 'Renewal Reminder',
-    description: 'Remind customers about upcoming renewals',
-    status: 'completed',
-    createdAt: '2025-04-15T09:45:00Z',
-    completedAt: '2025-04-20T14:30:00Z',
-    totalContacts: 45,
-    sentCount: 45,
-    responseCount: 28,
-    tags: ['renewal', 'existing-customers'],
-    message: 'Hi {{name}}, your subscription is due for renewal on {{renewal_date}}. Reply RENEW to continue your service.',
+    id: "c_003",
+    name: "Hook: Demo Scheduler",
+    type: "Hook",
+    status: "active",
+    createdBy: "Jordan Lee",
+    createdAt: "2025-05-19T15:05:00Z",
+    description: "Webhook-driven demo scheduling for inbound leads.",
+    templateId: "tpl_demo",
+    hookEndpoint: "/api/hooks/campaigns/c_003",
+    message:
+      "Hey {name}, thanks for requesting a demo. Pick a time here: {link}",
+    stats: {
+      sent: 214,
+      delivered: 206,
+      responded: 88,
+      stop: 2,
+      spam: 0,
+      clicks: 61,
+      segments: 262,
+    },
   },
   {
-    id: '4',
-    name: 'Product Announcement',
-    description: 'Announce new features to existing customers',
-    status: 'draft',
-    createdAt: '2025-05-20T08:15:00Z',
-    totalContacts: 0,
-    sentCount: 0,
-    responseCount: 0,
-    tags: ['announcement', 'product-update'],
-    message: 'Hi {{name}}, we\'ve just released some exciting new features! Check them out at onryl.com/new-features',
+    id: "c_004",
+    name: "Welcome Blast",
+    type: "Single blast",
+    status: "draft",
+    createdBy: "Avery Hill",
+    createdAt: "2025-05-23T10:20:00Z",
+    description: "New subscriber welcome sequence.",
+    message: "Welcome to Onryl! Reply HELP for support or STOP to opt out.",
+    stats: {
+      sent: 0,
+      delivered: 0,
+      responded: 0,
+      stop: 0,
+      spam: 0,
+      clicks: 0,
+      segments: 0,
+    },
   },
 ];
 
-// Function to get all campaigns
 export async function getCampaigns() {
-  // Simulate API request
-  return await new Promise((resolve) => {
+  return await new Promise<{ success: true; campaigns: CampaignRecord[] }>((resolve) => {
     setTimeout(() => {
       resolve({
         success: true,
-        campaigns: campaigns,
+        campaigns,
       });
-    }, 300);
+    }, 200);
   });
 }
 
-// Function to get a specific campaign by ID
 export async function getCampaign(id: string) {
-  // Simulate API request
-  return await new Promise((resolve) => {
+  return await new Promise<
+    | { success: true; campaign: CampaignRecord }
+    | { success: false; error: string }
+  >((resolve) => {
     setTimeout(() => {
-      const campaign = campaigns.find((c) => c.id === id);
-      
+      const campaign = campaigns.find((item) => item.id === id);
       if (campaign) {
-        resolve({
-          success: true,
-          campaign,
-        });
+        resolve({ success: true, campaign });
       } else {
-        resolve({
-          success: false,
-          error: 'Campaign not found',
-        });
+        resolve({ success: false, error: "Campaign not found" });
       }
-    }, 300);
+    }, 200);
   });
 }
 
-// Function to create a new campaign
-export async function createCampaign(campaignData: any) {
-  // Simulate API request
-  return await new Promise((resolve) => {
+export async function createCampaign(
+  campaignData: Pick<CampaignRecord, "name" | "message" | "description" | "type">
+) {
+  return await new Promise<{ success: true; campaign: CampaignRecord }>((resolve) => {
     setTimeout(() => {
-      const newCampaign = {
-        id: String(campaigns.length + 1),
+      const newCampaign: CampaignRecord = {
+        id: `c_${String(campaigns.length + 1).padStart(3, "0")}`,
+        status: "draft",
+        createdBy: "Avery Hill",
         createdAt: new Date().toISOString(),
-        sentCount: 0,
-        responseCount: 0,
-        status: 'draft',
+        stats: {
+          sent: 0,
+          delivered: 0,
+          responded: 0,
+          stop: 0,
+          spam: 0,
+          clicks: 0,
+          segments: 0,
+        },
         ...campaignData,
       };
-      
-      // In a real app, this would be added to the database
-      campaigns.push(newCampaign as any);
-      
-      resolve({
-        success: true,
-        campaign: newCampaign,
-      });
-    }, 300);
+      campaigns.push(newCampaign);
+      resolve({ success: true, campaign: newCampaign });
+    }, 200);
   });
 }
 
-// Function to update an existing campaign
-export async function updateCampaign(id: string, campaignData: any) {
-  // Simulate API request
-  return await new Promise((resolve) => {
-    setTimeout(() => {
-      const campaignIndex = campaigns.findIndex((c) => c.id === id);
-      
-      if (campaignIndex === -1) {
-        resolve({
-          success: false,
-          error: 'Campaign not found',
-        });
-        return;
-      }
-      
-      const updatedCampaign = {
-        ...campaigns[campaignIndex],
-        ...campaignData,
-      };
-      
-      // In a real app, this would update the record in the database
-      campaigns[campaignIndex] = updatedCampaign as any;
-      
-      resolve({
-        success: true,
-        campaign: updatedCampaign,
-      });
-    }, 300);
-  });
-}
-
-// Function to delete a campaign
-export async function deleteCampaign(id: string) {
-  // Simulate API request
-  return await new Promise((resolve) => {
-    setTimeout(() => {
-      const campaignIndex = campaigns.findIndex((c) => c.id === id);
-      
-      if (campaignIndex === -1) {
-        resolve({
-          success: false,
-          error: 'Campaign not found',
-        });
-        return;
-      }
-      
-      // In a real app, this would delete the record from the database
-      const deletedCampaign = campaigns.splice(campaignIndex, 1)[0];
-      
-      resolve({
-        success: true,
-        campaign: deletedCampaign,
-      });
-    }, 300);
-  });
-}
-
-// Function to run a campaign
 export async function runCampaign(id: string) {
-  // Simulate API request
-  return await new Promise((resolve) => {
+  return await new Promise<{ success: boolean; message: string }>((resolve) => {
     setTimeout(() => {
-      const campaign = campaigns.find((c) => c.id === id);
-      
-      if (!campaign) {
-        resolve({
-          success: false,
-          error: 'Campaign not found',
-        });
-        return;
-      }
-      
-      // In a real app, this would trigger the sending of messages
-      // through a job queue or similar mechanism
-      
       resolve({
         success: true,
-        message: `Campaign ${id} is now running`,
+        message: `Campaign ${id} queued for delivery.`,
       });
-    }, 300);
+    }, 200);
   });
 }
 
-// Function to pause a campaign
-export async function pauseCampaign(id: string) {
-  // Simulate API request
-  return await new Promise((resolve) => {
-    setTimeout(() => {
-      const campaignIndex = campaigns.findIndex((c) => c.id === id);
-      
-      if (campaignIndex === -1) {
-        resolve({
-          success: false,
-          error: 'Campaign not found',
-        });
-        return;
-      }
-      
-      const campaign = campaigns[campaignIndex];
-      
-      if (campaign.status !== 'active') {
-        resolve({
-          success: false,
-          error: 'Campaign is not active',
-        });
-        return;
-      }
-      
-      // In a real app, this would pause the sending of messages
-      campaigns[campaignIndex] = {
-        ...campaign,
-        status: 'paused',
-      } as any;
-      
-      resolve({
-        success: true,
-        message: `Campaign ${id} is now paused`,
-      });
-    }, 300);
-  });
-}
-
-// Function to resume a campaign
-export async function resumeCampaign(id: string) {
-  // Simulate API request
-  return await new Promise((resolve) => {
-    setTimeout(() => {
-      const campaignIndex = campaigns.findIndex((c) => c.id === id);
-      
-      if (campaignIndex === -1) {
-        resolve({
-          success: false,
-          error: 'Campaign not found',
-        });
-        return;
-      }
-      
-      const campaign = campaigns[campaignIndex];
-      
-      if (campaign.status !== 'paused') {
-        resolve({
-          success: false,
-          error: 'Campaign is not paused',
-        });
-        return;
-      }
-      
-      // In a real app, this would resume the sending of messages
-      campaigns[campaignIndex] = {
-        ...campaign,
-        status: 'active',
-      } as any;
-      
-      resolve({
-        success: true,
-        message: `Campaign ${id} is now active`,
-      });
-    }, 300);
-  });
-}
-
-// Export all functions
 export const campaignService = {
   getCampaigns,
   getCampaign,
   createCampaign,
-  updateCampaign,
-  deleteCampaign,
   runCampaign,
-  pauseCampaign,
-  resumeCampaign,
 };

--- a/src/lib/twilio-server.ts
+++ b/src/lib/twilio-server.ts
@@ -1,0 +1,70 @@
+import twilio, { type MessageInstance } from "twilio";
+
+export type TwilioSendOptions = {
+  from?: string;
+  messagingServiceSid?: string;
+  statusCallback?: string;
+  mediaUrl?: string | string[];
+  safeMode?: boolean;
+};
+
+type TwilioCredentials = {
+  accountSid: string;
+  authToken: string;
+};
+
+const getTwilioCredentials = (): TwilioCredentials => {
+  const accountSid = process.env.TWILIO_ACCOUNT_SID?.trim();
+  const authToken = process.env.TWILIO_AUTH_TOKEN?.trim();
+
+  if (!accountSid || !authToken) {
+    throw new Error("Twilio credentials are missing.");
+  }
+
+  return { accountSid, authToken };
+};
+
+const resolveMessagingSource = (options?: TwilioSendOptions) => {
+  const from = options?.from?.trim();
+  const messagingServiceSid = options?.messagingServiceSid?.trim()
+    ?? process.env.TWILIO_MESSAGING_SERVICE_SID?.trim();
+
+  if (from) {
+    return { from };
+  }
+
+  if (messagingServiceSid) {
+    return { messagingServiceSid };
+  }
+
+  throw new Error("A sender number or messaging service SID is required.");
+};
+
+export const sendTwilioMessage = async ({
+  to,
+  body,
+  options,
+}: {
+  to: string;
+  body: string;
+  options?: TwilioSendOptions;
+}): Promise<MessageInstance | { sid: string; status: string }> => {
+  if (options?.safeMode) {
+    return {
+      sid: `simulated-${Date.now()}`,
+      status: "simulated",
+    };
+  }
+
+  const { accountSid, authToken } = getTwilioCredentials();
+  const client = twilio(accountSid, authToken);
+  const source = resolveMessagingSource(options);
+
+  return client.messages.create({
+    to,
+    body,
+    ...source,
+    statusCallback: options?.statusCallback,
+    mediaUrl: options?.mediaUrl,
+  });
+};


### PR DESCRIPTION
### Motivation
- Align the app UI with the requested multi-panel SMS platform layout (left nav, top workspace header, messages inbox with filters, campaigns list/detail, workspace settings).
- Provide realistic client-side mock services and components so pages can be navigated and visually validated without a backend.
- Surface Hook campaign instructions and message builder controls to support the requested programmatic send workflow.

### Description
- Added a `TopBar` and extended `SideNav` links, and updated `DashboardLayout` to render a consistent workspace header above page content (`src/components/layout/TopBar.tsx`, `SideNav.tsx`, `DashboardLayout.tsx`).
- Rebuilt the Messages inbox into a three-column layout with filters, channel list, chat thread, composer with segment counter, safe-mode toggle, and channel metadata (`src/app/messages/page.tsx`).
- Reworked campaigns area: introduced a typed `campaign` lib with realistic records and APIs, replaced old mocks, and implemented a campaigns list and campaign detail (including Hook instructions, message builder, and metrics) (`src/lib/campaign.ts`, `src/app/campaigns/page.tsx`, `src/app/campaigns/[id]/page.tsx`).
- Added CRUD-style UI pages for Workspace settings, Claims (phone number provisioning), Contacts, Subscribers (segments), and Lookups to cover required routes (`src/app/workspace/page.tsx`, `src/app/claims/page.tsx`, `src/app/contacts/page.tsx`, `src/app/subscribers/page.tsx`, `src/app/lookups/page.tsx`).
- Minor UI/UX adjustments across components (badges, selects, tables, cards and buttons) and removed/replaced older campaign mock implementation with the new typed service.

### Testing
- Started the Next.js dev server with `npm run dev` and the app compiled and served pages (pages compiled; `/messages` returned HTTP 200). 
- Programmatically visited `/messages` with a Playwright script and captured a screenshot of the Messages page for visual verification (`artifacts/messages-page.png`), which completed successfully. 
- Build-time warnings occurred while downloading Google Fonts (fallback fonts used), but the pages still compiled and rendered; no unit or integration test suites were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69821ddef080832eab90aac922b2eaba)